### PR TITLE
Added helper functions for creating various Tcp packets

### DIFF
--- a/knet/src/main/kotlin/com/jasonernst/knet/network/ip/IpHeader.kt
+++ b/knet/src/main/kotlin/com/jasonernst/knet/network/ip/IpHeader.kt
@@ -67,6 +67,7 @@ interface IpHeader {
             }
             return when (sourceAddress) {
                 is Inet4Address -> {
+                    destinationAddress as Inet4Address
                     val totalLength = (IP4_MIN_HEADER_LENGTH + payloadSize.toUShort()).toUShort()
                     Ipv4Header(
                         sourceAddress = sourceAddress,
@@ -76,6 +77,7 @@ interface IpHeader {
                     )
                 }
                 is Inet6Address -> {
+                    destinationAddress as Inet6Address
                     Ipv6Header(
                         sourceAddress = sourceAddress,
                         destinationAddress = destinationAddress,

--- a/knet/src/main/kotlin/com/jasonernst/knet/network/ip/v4/Ipv4Header.kt
+++ b/knet/src/main/kotlin/com/jasonernst/knet/network/ip/v4/Ipv4Header.kt
@@ -10,9 +10,9 @@ import com.jasonernst.knet.network.ip.v4.options.Ipv4Option
 import com.jasonernst.knet.network.ip.v4.options.Ipv4Option.Companion.parseOptions
 import org.slf4j.LoggerFactory
 import java.net.Inet4Address
-import java.net.InetAddress
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
+import java.util.concurrent.atomic.AtomicInteger
 import kotlin.experimental.or
 import kotlin.math.ceil
 import kotlin.math.min
@@ -51,9 +51,9 @@ data class Ipv4Header(
     // https://en.wikipedia.org/wiki/IPv4#Header_checksum
     var headerChecksum: UShort = 0u,
     // 32-bits, source address
-    override val sourceAddress: InetAddress = Inet4Address.getLocalHost(),
+    override val sourceAddress: Inet4Address = Inet4Address.getLocalHost() as Inet4Address,
     // 32-bits, destination address
-    override val destinationAddress: InetAddress = Inet4Address.getLocalHost(),
+    override val destinationAddress: Inet4Address = Inet4Address.getLocalHost() as Inet4Address,
     val options: List<Ipv4Option> = emptyList(),
 ) : IpHeader {
     // 3-bits: set from mayFragment and lastFragment
@@ -81,7 +81,6 @@ data class Ipv4Header(
 
         // calculate the checksum for packet creation based on the set fields
         if (headerChecksum == 0u.toUShort()) {
-            logger.debug("Calculating checksum for IPv4 header")
             val buffer = toByteArray()
             // ^ this will compute the checksum and put it in the buffer
             // note: it's tempting to call the checksum function here but if we do we'll get a zero
@@ -92,6 +91,7 @@ data class Ipv4Header(
 
     companion object {
         private val logger = LoggerFactory.getLogger(Ipv4Header::class.java)
+        val packetCounter: AtomicInteger = AtomicInteger(0) // used to generate monotonic ids for Ipv4 packets
         private const val CHECKSUM_OFFSET = 10
         const val IP4_WORD_LENGTH: UByte = 4u
         val IP4_MIN_HEADER_LENGTH: UByte = (IP4_WORD_LENGTH * 5u).toUByte()

--- a/knet/src/main/kotlin/com/jasonernst/knet/network/ip/v6/Ipv6Header.kt
+++ b/knet/src/main/kotlin/com/jasonernst/knet/network/ip/v6/Ipv6Header.kt
@@ -10,7 +10,6 @@ import com.jasonernst.knet.network.ip.v6.extenions.Ipv6Fragment
 import com.jasonernst.knet.network.nextheader.NextHeader
 import org.slf4j.LoggerFactory
 import java.net.Inet6Address
-import java.net.InetAddress
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
 
@@ -31,9 +30,9 @@ data class Ipv6Header(
     // 8-bits: hop limit, decremented by 1 at each hop, if 0, packet is discarded, similar to TTL
     val hopLimit: UByte = 0u,
     // 128-bits: source address
-    override val sourceAddress: InetAddress = Inet6Address.getByName("::1"),
+    override val sourceAddress: Inet6Address = Inet6Address.getByName("::1") as Inet6Address,
     // 128-bits: destination address
-    override val destinationAddress: InetAddress = Inet6Address.getByName("::1"),
+    override val destinationAddress: Inet6Address = Inet6Address.getByName("::1") as Inet6Address,
     val extensionHeaders: List<Ipv6ExtensionHeader> = emptyList(),
 ) : IpHeader {
     init {

--- a/knet/src/main/kotlin/com/jasonernst/knet/transport/TransportHeader.kt
+++ b/knet/src/main/kotlin/com/jasonernst/knet/transport/TransportHeader.kt
@@ -9,7 +9,6 @@ import com.jasonernst.knet.network.ip.v6.Ipv6Header.Companion.IP6_HEADER_SIZE
 import com.jasonernst.knet.network.nextheader.NextHeader
 import com.jasonernst.knet.transport.tcp.TcpHeader
 import com.jasonernst.knet.transport.udp.UdpHeader
-import com.jasonernst.packetdumper.stringdumper.StringPacketDumper
 import org.slf4j.LoggerFactory
 import java.nio.ByteBuffer
 
@@ -79,7 +78,6 @@ interface TransportHeader : NextHeader {
             }
         }
         pseudoHeader.rewind()
-        logger.debug("Pseudo header: {}", StringPacketDumper().dumpBufferToString(pseudoHeader))
         val computedChecksum = Checksum.calculateChecksum(pseudoHeader)
 
         if (verify) {

--- a/knet/src/main/kotlin/com/jasonernst/knet/transport/tcp/TcpHeaderFactory.kt
+++ b/knet/src/main/kotlin/com/jasonernst/knet/transport/tcp/TcpHeaderFactory.kt
@@ -1,0 +1,311 @@
+package com.jasonernst.knet.transport.tcp
+
+import com.jasonernst.knet.Packet
+import com.jasonernst.knet.network.ip.IpHeader
+import com.jasonernst.knet.network.ip.IpType
+import com.jasonernst.knet.network.ip.v4.Ipv4Header
+import com.jasonernst.knet.network.ip.v4.Ipv4Header.Companion.packetCounter
+import com.jasonernst.knet.network.ip.v6.Ipv6Header
+import com.jasonernst.knet.transport.tcp.TcpHeader.Companion.DEFAULT_WINDOW_SIZE
+import com.jasonernst.knet.transport.tcp.options.TcpOption
+import com.jasonernst.knet.transport.tcp.options.TcpOptionEndOfOptionList
+import com.jasonernst.knet.transport.tcp.options.TcpOptionMaximumSegmentSize
+import java.net.Inet4Address
+import java.net.Inet6Address
+import java.net.InetAddress
+import java.nio.ByteBuffer
+import java.util.Random
+
+object TcpHeaderFactory {
+    /**
+     * Performs a bunch of common steps regardless of the response:
+     * 1. Copies the headers so we still have the originals
+     * 2. Sets the Flags
+     * 2. Sets the SEQ and ACK numbers
+     * 3. optionally swaps source and dest addresses and ports
+     * 4. computes the checksum
+     * 5. returns the packet
+     * @param ipHeader the IP header to base the response from
+     * @param transportHeader the transport header to base the response from
+     * @param seqNumber the sequence number to set in the response
+     * @param ackNumber the acknowledgement number to set in the response
+     * @param swapSourceAndDestination whether to swap the source and destination addresses and
+     * ports
+     * @param payload the payload to include in the response and use for checksum calculation
+     *  can use ByteBuffer.allocate(0) if no payload
+     *
+     *  NB: at the end of this, the payload position is set to payload.limit()
+     */
+    fun prepareResponseHeaders(
+        ipHeader: IpHeader,
+        tcpHeader: TcpHeader,
+        seqNumber: UInt,
+        ackNumber: UInt,
+        swapSourceAndDestination: Boolean = true,
+        payload: ByteBuffer = ByteBuffer.allocate(0),
+        isSyn: Boolean = false,
+        isAck: Boolean = false,
+        isPsh: Boolean = false,
+        isFin: Boolean = false,
+        isRst: Boolean = false,
+        isUrg: Boolean = false,
+        windowSize: UShort = DEFAULT_WINDOW_SIZE,
+        urgentPointer: UShort = 0u,
+        options: List<TcpOption> = emptyList(),
+    ): Packet {
+        require(ipHeader.sourceAddress::class == ipHeader.destinationAddress::class) {
+            "IP header source and destination addresses must be the same type"
+        }
+
+        // if we want to respond with different options this is the place to do it
+        val responseTcpHeader =
+            TcpHeader(
+                sourcePort = tcpHeader.sourcePort,
+                destinationPort = tcpHeader.destinationPort,
+                sequenceNumber = seqNumber,
+                acknowledgementNumber = ackNumber,
+                windowSize = windowSize,
+                urgentPointer = urgentPointer,
+                options = options,
+            )
+
+        val payloadCopy = ByteArray(payload.remaining())
+        payload.get(payloadCopy)
+
+        responseTcpHeader.setSyn(isSyn)
+        responseTcpHeader.setAck(isAck)
+        responseTcpHeader.setPsh(isPsh)
+        responseTcpHeader.setFin(isFin)
+        responseTcpHeader.setRst(isRst)
+        responseTcpHeader.setUrg(isUrg)
+
+        val sourceAddress = if (swapSourceAndDestination) ipHeader.destinationAddress else ipHeader.sourceAddress
+        val destinationAddress = if (swapSourceAndDestination) ipHeader.sourceAddress else ipHeader.destinationAddress
+
+        val totalLength = (ipHeader.getHeaderLength() + responseTcpHeader.getHeaderLength() + payloadCopy.size.toUInt()).toUShort()
+
+        val responseIpHeader =
+            when (sourceAddress) {
+                is Inet4Address -> {
+                    destinationAddress as Inet4Address
+                    Ipv4Header(
+                        id = packetCounter.getAndIncrement().toUShort(),
+                        sourceAddress = sourceAddress,
+                        destinationAddress = destinationAddress,
+                        protocol = ipHeader.protocol,
+                        totalLength = totalLength,
+                    )
+                }
+
+                is Inet6Address -> {
+                    destinationAddress as Inet6Address
+                    Ipv6Header(
+                        sourceAddress = sourceAddress,
+                        destinationAddress = destinationAddress,
+                        protocol = ipHeader.protocol,
+                        payloadLength = totalLength,
+                    )
+                }
+
+                else -> {
+                    throw IllegalArgumentException("Unknown IP address type")
+                }
+            }
+        responseTcpHeader.checksum = responseTcpHeader.computeChecksum(responseIpHeader, payloadCopy)
+        return Packet(responseIpHeader, responseTcpHeader, payloadCopy)
+    }
+
+    /**
+     * Given a TCP packet, create an ACK packet with the given ackNumber of how many bytes we
+     * are acknowledging we have received.
+     *
+     * Note: we don't just look at the previous TCP header to determine the ackNumber because it
+     * depends on how many bytes we are acknowledging we have received (computed by a TCP state machine
+     * or something that is out of the scope of this library).
+     *
+     * Similarly, the sequence number we send back depends on the current state of the TCP state machine and isn't
+     * always based on the ACK number of the previous packet.
+     *
+     * @param ipHeader the IP header of the packet we are responding to
+     * @param tcpHeader the TCP header of the packet we are responding to
+     * @param seqNumber the sequence number to use in the response
+     * @param ackNumber the acknowledgement number to use in the response
+     * @param payload the payload to attach to the ACK (may be empty)
+     */
+    fun createAckPacket(
+        ipHeader: IpHeader,
+        tcpHeader: TcpHeader,
+        seqNumber: UInt,
+        ackNumber: UInt,
+        payload: ByteBuffer = ByteBuffer.allocate(0),
+        isPsh: Boolean = false,
+        windowSize: UShort = DEFAULT_WINDOW_SIZE,
+    ): Packet =
+        prepareResponseHeaders(
+            ipHeader,
+            tcpHeader,
+            seqNumber,
+            ackNumber,
+            payload = payload,
+            isAck = true,
+            isPsh = isPsh,
+            windowSize = windowSize,
+        )
+
+    /**
+     * Given an ipHeader, tcpHeader, constructs a FIN packet with the given seq, ack numbers
+     */
+    fun createFinPacket(
+        ipHeader: IpHeader,
+        tcpHeader: TcpHeader,
+        seqNumber: UInt,
+        ackNumber: UInt,
+    ): Packet =
+        prepareResponseHeaders(
+            ipHeader,
+            tcpHeader,
+            seqNumber,
+            ackNumber,
+            isFin = true,
+            isAck = true,
+        )
+
+    /**
+     * Given the last received packet from the client, create an RST packet to reset the connection.
+     *
+     * This is typically for when something went wonky and we need the other side to start again.
+     *
+     * Note the seq number must be the next expected seq number for the client based on the last
+     * packet, or it won't take effect: https://www.rfc-editor.org/rfc/rfc5961#section-3.2
+     *
+     * This is because there is an attack where you could force resets without this.
+     */
+    fun createRstPacket(
+        ipHeader: IpHeader,
+        tcpHeader: TcpHeader,
+    ): Packet {
+        // page 36: RFC 793 https://datatracker.ietf.org/doc/html/rfc793#section-3.2
+        // If the incoming segment has an ACK field, the reset takes its
+        //    sequence number from the ACK field of the segment, otherwise the
+        //    reset has sequence number zero and the ACK field is set to the sum
+        //    of the sequence number and segment length of the incoming segment.
+        //    The connection remains in the CLOSED state.
+        val ackNumber: UInt
+        val seqNumber: UInt
+
+        // see page 64
+        if (tcpHeader.isAck()) {
+            seqNumber = tcpHeader.acknowledgementNumber
+            ackNumber = 0u
+        } else {
+            seqNumber = 0u
+            ackNumber = tcpHeader.sequenceNumber + ipHeader.getPayloadLength().toUInt() -
+                tcpHeader.getHeaderLength().toUInt()
+        }
+
+        return prepareResponseHeaders(
+            ipHeader,
+            tcpHeader,
+            seqNumber,
+            ackNumber,
+            swapSourceAndDestination = true,
+            isRst = true,
+        )
+    }
+
+    /**
+     * This is only used for tests, the OS creates the SYN packets, not us.
+     *
+     * NB: the source and destination should not be swapped when we create the SYN packet since
+     * we are providing a previous packet from the other side to copy from.
+     *
+     * Technically the SYN packet supports payloads, but we don't use them here.
+     *
+     * @param sourceAddress the source address of the SYN packet
+     * @param destinationAddress the destination address of the SYN packet
+     * @param sourcePort the source port of the SYN packet
+     * @param destinationPort the destinationPort
+     * @param startingSeq the sequence number to start the TCP session with
+     */
+    fun createSynPacket(
+        sourceAddress: InetAddress,
+        destinationAddress: InetAddress,
+        sourcePort: UShort,
+        destinationPort: UShort,
+        startingSeq: UInt,
+        mss: UShort,
+    ): Packet {
+        val tcpHeader = TcpHeader(sourcePort, destinationPort, startingSeq, 0u)
+        val tcpOptions = listOf(TcpOptionMaximumSegmentSize(mss), TcpOptionEndOfOptionList())
+
+        val ipHeader =
+            IpHeader.createIPHeader(
+                sourceAddress,
+                destinationAddress,
+                IpType.TCP,
+                tcpHeader.getHeaderLength().toInt(),
+            )
+
+        return prepareResponseHeaders(
+            ipHeader,
+            tcpHeader,
+            startingSeq,
+            0u,
+            swapSourceAndDestination = false,
+            isSyn = true,
+            options = tcpOptions,
+        )
+    }
+
+    /**
+     * Given a SYN packet, create a SYN-ACK packet to send back to the client. Note the IP and TCP
+     * source / destination returned will be returned swapped from those sent to this function.
+     *
+     * The sequence number will be randomly generated. The acknowledgement number will be the the
+     * previously received sequence number + 1
+     * (see https://datatracker.ietf.org/doc/html/rfc793#section-3.2)
+     *
+     * NB: While TCP supports sending data in the SYN packet, we do not for now.
+     *
+     * @param ipHeader the IP header of the SYN packet
+     * @param tcpHeader the TCP header of the SYN packet
+     *
+     * @return A Packet with the SYN-ACK packet encapsulated in the IP and TCP headers
+     */
+    fun createSynAckPacket(
+        ipHeader: IpHeader,
+        tcpHeader: TcpHeader,
+        mss: UShort,
+    ): Packet {
+        require(tcpHeader.isSyn()) { "Cannot create SYN-ACK packet for non-SYN packet" }
+        val tcpOptions = listOf(TcpOptionMaximumSegmentSize(mss), TcpOptionEndOfOptionList())
+        // use a random sequence number because we're just starting the session
+        // todo: probably update this to not be random using this approach:
+        //   pg: 27 https://datatracker.ietf.org/doc/html/rfc793
+        // To avoid confusion we must prevent segments from one incarnation of a
+        //  connection from being used while the same sequence numbers may still
+        //  be present in the network from an earlier incarnation.  We want to
+        //  assure this, even if a TCP crashes and loses all knowledge of the
+        //  sequence numbers it has been using.  When new connections are created,
+        //  an initial sequence number (ISN) generator is employed which selects a
+        //  new 32 bit ISN.  The generator is bound to a (possibly fictitious) 32
+        //  bit clock whose low order bit is incremented roughly every 4
+        //  microseconds.  Thus, the ISN cycles approximately every 4.55 hours.
+        //  Since we assume that segments will stay in the network no more than
+        //  the Maximum Segment Lifetime (MSL) and that the MSL is less than 4.55
+        //  hours we can reasonably assume that ISN's will be unique.
+        return prepareResponseHeaders(
+            ipHeader,
+            tcpHeader,
+            Random().nextInt().toUInt(),
+            tcpHeader.sequenceNumber + 1u,
+            true,
+            ByteBuffer.allocate(0),
+            true,
+            true,
+            false,
+            false,
+            options = tcpOptions,
+        )
+    }
+}

--- a/knet/src/test/kotlin/com/jasonernst/knet/network/ip/v4/Ipv4FragmentTest.kt
+++ b/knet/src/test/kotlin/com/jasonernst/knet/network/ip/v4/Ipv4FragmentTest.kt
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.Assertions.assertArrayEquals
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
-import java.net.InetAddress
+import java.net.Inet4Address
 import kotlin.math.ceil
 
 class Ipv4FragmentTest {
@@ -85,12 +85,12 @@ class Ipv4FragmentTest {
             Ipv4Header.reassemble(listOf(Pair(ipv4Header, ByteArray(0)), Pair(ipv4Header3, ByteArray(0))))
         }
 
-        val ipv4Header4 = Ipv4Header(id = 1u, sourceAddress = InetAddress.getLoopbackAddress())
+        val ipv4Header4 = Ipv4Header(id = 1u, sourceAddress = Inet4Address.getByName("127.0.0.1") as Inet4Address)
         assertThrows<IllegalArgumentException> {
             Ipv4Header.reassemble(listOf(Pair(ipv4Header, ByteArray(0)), Pair(ipv4Header4, ByteArray(0))))
         }
 
-        val ipv4Header5 = Ipv4Header(id = 1u, destinationAddress = InetAddress.getLoopbackAddress())
+        val ipv4Header5 = Ipv4Header(id = 1u, destinationAddress = Inet4Address.getByName("127.0.0.1") as Inet4Address)
         assertThrows<IllegalArgumentException> {
             Ipv4Header.reassemble(listOf(Pair(ipv4Header, ByteArray(0)), Pair(ipv4Header5, ByteArray(0))))
         }

--- a/knet/src/test/kotlin/com/jasonernst/knet/network/ip/v4/Ipv4HeaderTest.kt
+++ b/knet/src/test/kotlin/com/jasonernst/knet/network/ip/v4/Ipv4HeaderTest.kt
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.slf4j.LoggerFactory
+import java.net.Inet4Address
 import java.net.InetAddress
 import java.nio.ByteBuffer
 
@@ -97,8 +98,8 @@ class Ipv4HeaderTest {
 
     @Test
     fun toBufferDontFragmentTest() {
-        val source = InetAddress.getByName("127.0.0.1")
-        val destination = InetAddress.getByName("8.8.8.8")
+        val source = InetAddress.getByName("127.0.0.1") as Inet4Address
+        val destination = InetAddress.getByName("8.8.8.8") as Inet4Address
         // don't fragment = false
         val fragment =
             Ipv4Header(
@@ -151,8 +152,8 @@ class Ipv4HeaderTest {
 
     @Test
     fun toFragmentOffsetTest() {
-        val source = InetAddress.getByName("127.0.0.1")
-        val destination = InetAddress.getByName("8.8.8.8")
+        val source = InetAddress.getByName("127.0.0.1") as Inet4Address
+        val destination = InetAddress.getByName("8.8.8.8") as Inet4Address
         // don't fragment = false
         val ipv4header =
             Ipv4Header(
@@ -180,8 +181,8 @@ class Ipv4HeaderTest {
 
     @Test
     fun toBufferDscpEcnTest() {
-        val source = InetAddress.getByName("127.0.0.1")
-        val destination = InetAddress.getByName("8.8.8.8")
+        val source = InetAddress.getByName("127.0.0.1") as Inet4Address
+        val destination = InetAddress.getByName("8.8.8.8") as Inet4Address
         // don't fragment = false
         val ipv4header =
             Ipv4Header(

--- a/knet/src/test/kotlin/com/jasonernst/knet/network/ip/v6/extensions/Ipv6ExtensionHeaderTest.kt
+++ b/knet/src/test/kotlin/com/jasonernst/knet/network/ip/v6/extensions/Ipv6ExtensionHeaderTest.kt
@@ -43,8 +43,8 @@ class Ipv6ExtensionHeaderTest {
                 flowLabel = 0x12345u,
                 protocol = IpType.HOPOPT.value,
                 hopLimit = 0x40u,
-                sourceAddress = Inet6Address.getByName("::1"),
-                destinationAddress = Inet6Address.getByName("::1"),
+                sourceAddress = Inet6Address.getByName("::1") as Inet6Address,
+                destinationAddress = Inet6Address.getByName("::1") as Inet6Address,
                 extensionHeaders = ipv6ExtensionHeaders,
                 payloadLength = payloadLength.toUShort(),
             )

--- a/knet/src/test/kotlin/com/jasonernst/knet/transport/tcp/TcpTests.kt
+++ b/knet/src/test/kotlin/com/jasonernst/knet/transport/tcp/TcpTests.kt
@@ -1,6 +1,8 @@
 package com.jasonernst.knet.transport.tcp
 
 import com.jasonernst.knet.PacketTooShortException
+import com.jasonernst.knet.network.ip.v4.Ipv4Header
+import com.jasonernst.knet.network.ip.v6.Ipv6Header
 import com.jasonernst.knet.transport.tcp.TcpHeader.Companion.BYTES_TO_DATA_OFFSET
 import com.jasonernst.knet.transport.tcp.options.TcpOptionEndOfOptionList
 import com.jasonernst.knet.transport.tcp.options.TcpOptionNoOperation
@@ -10,6 +12,7 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import java.net.InetAddress
 import java.nio.ByteBuffer
 
 class TcpTests {
@@ -71,5 +74,96 @@ class TcpTests {
         val stream = ByteBuffer.wrap(tcpHeader.toByteArray())
         val parsedHeader = TcpHeader.fromStream(stream)
         assertEquals(parsedHeader, tcpHeader)
+    }
+
+    @Test fun createAckPacketTest() {
+        val tcpHeader = TcpHeader()
+        val ipHeader = Ipv4Header(totalLength = (Ipv4Header.IP4_MIN_HEADER_LENGTH + tcpHeader.getHeaderLength()).toUShort())
+
+        val ackPacket =
+            TcpHeaderFactory.createAckPacket(
+                ipHeader,
+                tcpHeader,
+                ackNumber = 0u,
+                seqNumber = Ipv4Header.packetCounter.getAndIncrement().toUInt(),
+            )
+        assertTrue(ackPacket.nextHeaders is TcpHeader)
+        val createdTcpHeader = ackPacket.nextHeaders as TcpHeader
+        assertTrue(createdTcpHeader.isAck())
+    }
+
+    @Test fun createFinPacketTest() {
+        val tcpHeader = TcpHeader()
+        val ipHeader = Ipv4Header(totalLength = (Ipv4Header.IP4_MIN_HEADER_LENGTH + tcpHeader.getHeaderLength()).toUShort())
+
+        val finPacket =
+            TcpHeaderFactory.createFinPacket(
+                ipHeader,
+                tcpHeader,
+                ackNumber = 0u,
+                seqNumber = Ipv4Header.packetCounter.getAndIncrement().toUInt(),
+            )
+        assertTrue(finPacket.nextHeaders is TcpHeader)
+        val createdTcpHeader = finPacket.nextHeaders as TcpHeader
+        assertTrue(createdTcpHeader.isFin())
+    }
+
+    @Test fun createRstPacketTest() {
+        // tcp header is not an ACK
+        val tcpHeader = TcpHeader()
+        val ipHeader = Ipv4Header(totalLength = (Ipv4Header.IP4_MIN_HEADER_LENGTH + tcpHeader.getHeaderLength()).toUShort())
+        val rstPacket =
+            TcpHeaderFactory.createRstPacket(
+                ipHeader,
+                tcpHeader,
+            )
+        assertTrue(rstPacket.nextHeaders is TcpHeader)
+        val createdTcpHeader = rstPacket.nextHeaders as TcpHeader
+        assertTrue(createdTcpHeader.isRst())
+        assertEquals(0u, createdTcpHeader.sequenceNumber)
+        val expectedAck = tcpHeader.sequenceNumber + ipHeader.getPayloadLength().toUInt() - tcpHeader.getHeaderLength()
+        assertEquals(expectedAck, createdTcpHeader.acknowledgementNumber)
+
+        // tcp header is an ACK
+        val tcpHeader2 = TcpHeader(ack = true, sequenceNumber = 56u, acknowledgementNumber = 24u)
+        val ipHeader2 = Ipv6Header(payloadLength = tcpHeader2.getHeaderLength())
+        val rstPacket2 =
+            TcpHeaderFactory.createRstPacket(
+                ipHeader2,
+                tcpHeader2,
+            )
+        assertTrue(rstPacket2.nextHeaders is TcpHeader)
+        val createdTcpHeader2 = rstPacket2.nextHeaders as TcpHeader
+        assertTrue(createdTcpHeader2.isRst())
+        assertEquals(tcpHeader2.acknowledgementNumber, createdTcpHeader2.sequenceNumber)
+        assertEquals(0u, createdTcpHeader2.acknowledgementNumber)
+    }
+
+    @Test fun createSynPacketTest() {
+        val synPacket = TcpHeaderFactory.createSynPacket(InetAddress.getLocalHost(), InetAddress.getLocalHost(), 56u, 85u, 22u, 1500u)
+        assertTrue(synPacket.nextHeaders is TcpHeader)
+        val createdTcpHeader = synPacket.nextHeaders as TcpHeader
+        assertTrue(createdTcpHeader.isSyn())
+        assertEquals(22u, createdTcpHeader.sequenceNumber)
+        assertEquals(56u, createdTcpHeader.sourcePort.toUInt())
+        assertEquals(85u, createdTcpHeader.destinationPort.toUInt())
+    }
+
+    @Test fun createSynAckPacket() {
+        val synPacket = TcpHeaderFactory.createSynPacket(InetAddress.getLocalHost(), InetAddress.getLocalHost(), 56u, 85u, 22u, 1500u)
+        val synAckPacket = TcpHeaderFactory.createSynAckPacket(synPacket.ipHeader, synPacket.nextHeaders as TcpHeader, 1500u)
+        assertTrue(synAckPacket.nextHeaders is TcpHeader)
+        val createdTcpHeader = synAckPacket.nextHeaders as TcpHeader
+        assertTrue(createdTcpHeader.isSyn())
+        assertTrue(createdTcpHeader.isAck())
+
+        // the syn-ack packet should have the ack number set to the sequence number of the syn packet + 1
+        assertEquals(23u, createdTcpHeader.acknowledgementNumber)
+
+        // call with a non-syn packet
+        val nonSynPacket = TcpHeader()
+        assertThrows<IllegalArgumentException> {
+            TcpHeaderFactory.createSynAckPacket(synPacket.ipHeader, nonSynPacket, 1500u)
+        }
     }
 }


### PR DESCRIPTION
Adds a factory class for creating various Tcp packets:
- ACK
- FIN
- RST
- SYN
- SYN-ACK

Also adds test coverage to ensure they all work.

Fixes: https://github.com/compscidr/knet/issues/30