### PR TITLE
Open interface for packet, add sentinel packet

### DIFF
--- a/src/main/kotlin/com/jasonernst/knet/Packet.kt
+++ b/src/main/kotlin/com/jasonernst/knet/Packet.kt
@@ -11,10 +11,10 @@ import java.nio.ByteOrder
  * only a single next header if we have an IPv4 packet, but could be more if we have an IPv6 packet
  * with hop-by-hop options, for example).
  */
-data class Packet(
-    val ipHeader: IpHeader,
-    val nextHeaders: NextHeader,
-    val payload: ByteArray,
+open class Packet(
+    val ipHeader: IpHeader?,
+    val nextHeaders: NextHeader?,
+    val payload: ByteArray?,
 ) {
     private val logger = LoggerFactory.getLogger(javaClass)
 
@@ -38,11 +38,14 @@ data class Packet(
     }
 
     fun toByteArray(order: ByteOrder = ByteOrder.BIG_ENDIAN): ByteArray {
+        if (ipHeader == null) {
+            return ByteArray(0)
+        }
         val buffer = ByteBuffer.allocate(ipHeader.getTotalLength().toInt())
         buffer.order(order)
         val ipHeaderBytes = ipHeader.toByteArray()
         buffer.put(ipHeaderBytes)
-        val nextHeaderBytes = nextHeaders.toByteArray()
+        val nextHeaderBytes = nextHeaders?.toByteArray()
         buffer.put(nextHeaderBytes)
         buffer.put(payload)
         return buffer.array()

--- a/src/main/kotlin/com/jasonernst/knet/SentinelPacket.kt
+++ b/src/main/kotlin/com/jasonernst/knet/SentinelPacket.kt
@@ -1,0 +1,6 @@
+package com.jasonernst.knet
+
+/**
+ * Used to indicate a shutting down of the packet processing pipeline.
+ */
+object SentinelPacket: Packet(null, null, null)

--- a/src/main/kotlin/com/jasonernst/knet/SentinelPacket.kt
+++ b/src/main/kotlin/com/jasonernst/knet/SentinelPacket.kt
@@ -3,4 +3,4 @@ package com.jasonernst.knet
 /**
  * Used to indicate a shutting down of the packet processing pipeline.
  */
-object SentinelPacket: Packet(null, null, null)
+object SentinelPacket : Packet(null, null, null)

--- a/src/test/kotlin/com/jasonernst/knet/PacketTests.kt
+++ b/src/test/kotlin/com/jasonernst/knet/PacketTests.kt
@@ -88,7 +88,7 @@ class PacketTests {
         assertNotEquals(packet, Any())
         assertEquals(packet, packet)
 
-        val packet5 = packet.copy()
+        val packet5 = Packet(ipHeader, tcpHeader, ByteArray(0))
         assertEquals(packet.ipHeader, packet5.ipHeader)
         assertEquals(packet.nextHeaders, packet5.nextHeaders)
         assertArrayEquals(packet.payload, packet5.payload)


### PR DESCRIPTION
In order to break out of processing loops using the `LinkedBlockingDeque` - a sentinel packet can be queued to indicate the end of processing