### PR TITLE
Make dnsrdata more readable

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,5 @@ Kotlin user-space network stack. This can be used for:
 - [x] ICMP (via https://github.com/compscidr/icmp)
 - [ ] TCP
 - [ ] UDP
+- [ ] DNS
+  - [ ] RFC 1035 (WiP): https://datatracker.ietf.org/doc/html/rfc1035

--- a/src/main/kotlin/com/jasonernst/knet/application/dns/DnsARData.kt
+++ b/src/main/kotlin/com/jasonernst/knet/application/dns/DnsARData.kt
@@ -1,0 +1,17 @@
+package com.jasonernst.knet.application.dns
+
+import java.net.Inet4Address
+import java.nio.ByteBuffer
+
+class DnsARData(
+    val address: Inet4Address,
+) : DnsRData(data = address.address) {
+    companion object {
+        fun fromStream(stream: ByteBuffer): DnsARData {
+            val inet4Address = Inet4Address.getByAddress(ByteArray(4) { stream.get() }) as Inet4Address
+            return DnsARData(inet4Address)
+        }
+    }
+
+    override fun toString(): String = "DnsARData(address=$address)"
+}

--- a/src/main/kotlin/com/jasonernst/knet/application/dns/DnsHeader.kt
+++ b/src/main/kotlin/com/jasonernst/knet/application/dns/DnsHeader.kt
@@ -25,7 +25,7 @@ data class DnsHeader(
         const val DNS_HEADER_LENGTH = 12
 
         fun fromStream(stream: ByteBuffer): DnsHeader {
-            if (stream.limit() < DNS_HEADER_LENGTH) {
+            if (stream.remaining() < DNS_HEADER_LENGTH) {
                 throw PacketTooShortException(
                     "Not enough bytes to parse a DNS header, need at least $DNS_HEADER_LENGTH, have ${stream.limit()}",
                 )

--- a/src/main/kotlin/com/jasonernst/knet/application/dns/DnsRData.kt
+++ b/src/main/kotlin/com/jasonernst/knet/application/dns/DnsRData.kt
@@ -1,16 +1,44 @@
 package com.jasonernst.knet.application.dns
 
+import com.jasonernst.knet.PacketTooShortException
+import com.jasonernst.packetdumper.stringdumper.StringPacketDumper
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
-import kotlin.properties.Delegates
 
-class DnsRData(
+open class DnsRData(
     private var data: ByteArray,
 ) {
-    private var length by Delegates.notNull<Short>()
+    private val stringPacketDumper = StringPacketDumper()
 
     init {
         setData(data)
+    }
+
+    companion object {
+        fun fromStream(
+            stream: ByteBuffer,
+            qType: DnsType,
+        ): DnsRData {
+            if (stream.remaining() < 2) {
+                throw PacketTooShortException("Not enough bytes to determine DNSRecord RDATA length, need 2, have ${stream.remaining()}")
+            }
+            val rdLength = stream.short.toUShort()
+            if (stream.remaining() < rdLength.toInt()) {
+                throw PacketTooShortException(
+                    "Not enough bytes to parse DNSRecord RDATA need at least $rdLength more, have ${stream.remaining()}",
+                )
+            }
+
+            // specific type
+            if (qType == DnsType.A) {
+                return DnsARData.fromStream(stream)
+            }
+
+            // otherwise, generic type
+            val rDataBytes = ByteArray(rdLength.toInt())
+            stream.get(rDataBytes)
+            return DnsRData(rDataBytes)
+        }
     }
 
     fun setData(data: ByteArray) {
@@ -29,4 +57,6 @@ class DnsRData(
         buffer.put(data)
         return buffer.array()
     }
+
+    override fun toString(): String = "DnsRData(data=${stringPacketDumper.dumpBufferToString(ByteBuffer.wrap(data))})"
 }

--- a/src/main/kotlin/com/jasonernst/knet/application/dns/DnsRecord.kt
+++ b/src/main/kotlin/com/jasonernst/knet/application/dns/DnsRecord.kt
@@ -33,15 +33,8 @@ data class DnsRecord(
             val qClass = stream.short.toUShort()
             logger.debug("GOT qType $qType, qClass $qClass")
             val ttl = stream.int.toUInt()
-            val rdLength = stream.short.toUShort()
-            if (stream.remaining() < rdLength.toInt()) {
-                throw PacketTooShortException(
-                    "Not enough bytes to parse DNSRecord RDATA need at least $rdLength more, have ${stream.remaining()}",
-                )
-            }
-            val rDataBytes = ByteArray(rdLength.toInt())
-            stream.get(rDataBytes)
-            return DnsRecord(qNames, DnsType.fromValue(qType), ttl, DnsRData(rDataBytes))
+            val rData = DnsRData.fromStream(stream, DnsType.fromValue(qType))
+            return DnsRecord(qNames, DnsType.fromValue(qType), ttl, rData)
         }
     }
 


### PR DESCRIPTION
- start of making rdata types (for now just A records)
 - convert a record type to Inet4Address
 - fall back to generic type for unsupported and just do a hexdump of the data