### PR TITLE
Fixed transport layer checksums

### DIFF
--- a/src/main/kotlin/com/jasonernst/knet/Packet.kt
+++ b/src/main/kotlin/com/jasonernst/knet/Packet.kt
@@ -2,6 +2,7 @@ package com.jasonernst.knet
 
 import com.jasonernst.knet.network.ip.IpHeader
 import com.jasonernst.knet.network.nextheader.NextHeader
+import com.jasonernst.knet.transport.TransportHeader
 import org.slf4j.LoggerFactory
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
@@ -45,6 +46,10 @@ open class Packet(
         buffer.order(order)
         val ipHeaderBytes = ipHeader.toByteArray()
         buffer.put(ipHeaderBytes)
+
+        if (nextHeaders is TransportHeader) {
+            nextHeaders.checksum = nextHeaders.computeChecksum(ipHeader, payload ?: ByteArray(0))
+        }
         val nextHeaderBytes = nextHeaders?.toByteArray()
         buffer.put(nextHeaderBytes)
         buffer.put(payload)

--- a/src/test/kotlin/com/jasonernst/knet/EncapsulationTests.kt
+++ b/src/test/kotlin/com/jasonernst/knet/EncapsulationTests.kt
@@ -8,6 +8,8 @@ import com.jasonernst.knet.transport.tcp.TcpHeader
 import com.jasonernst.knet.transport.udp.UdpHeader
 import com.jasonernst.packetdumper.stringdumper.StringPacketDumper
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Timeout
 import org.slf4j.LoggerFactory
@@ -170,5 +172,50 @@ class EncapsulationTests {
         val stream = ByteBuffer.wrap(packet.toByteArray())
         val parsedPacket = Packet.fromStream(stream)
         assertEquals(packet, parsedPacket)
+    }
+
+    @Test fun nonZeroChecksums() {
+        val payload = "test".toByteArray()
+        val sourcePort = Random.Default.nextInt(2 * Short.MAX_VALUE - 1)
+        val sourceAddress = InetSocketAddress(InetAddress.getByName("::1"), sourcePort)
+        val destPort = Random.Default.nextInt(2 * Short.MAX_VALUE - 1)
+        val destinationAddress = InetSocketAddress(InetAddress.getByName("::2"), destPort)
+
+        val tcpHeader =
+            TcpHeader(
+                sourcePort = sourcePort.toUShort(),
+                destinationPort = destPort.toUShort(),
+                sequenceNumber = 100u,
+                acknowledgementNumber = 500u,
+                windowSize = 35000.toUShort(),
+            )
+        val ipHeader =
+            IpHeader.createIPHeader(
+                sourceAddress.address,
+                destinationAddress.address,
+                IpType.TCP,
+                tcpHeader.getHeaderLength().toInt() + payload.size,
+            )
+        val packet = Packet(ipHeader, tcpHeader, payload)
+        val stream = ByteBuffer.wrap(packet.toByteArray())
+        val parsedPacket = Packet.fromStream(stream)
+        assertNotEquals(0u, (parsedPacket.nextHeaders as TcpHeader).checksum)
+        // edge case where we had extra left in the stream
+        assertFalse(stream.hasRemaining())
+
+        val udpHeader = UdpHeader(sourcePort.toUShort(), destPort.toUShort(), payload.size.toUShort(), 0u)
+        val ipHeader2 =
+            IpHeader.createIPHeader(
+                sourceAddress.address,
+                destinationAddress.address,
+                IpType.UDP,
+                udpHeader.getHeaderLength().toInt() + payload.size,
+            )
+        val packet2 = Packet(ipHeader2, udpHeader, payload)
+        val stream2 = ByteBuffer.wrap(packet2.toByteArray())
+        val parsedPacket2 = Packet.fromStream(stream2)
+        assertNotEquals(0u, (parsedPacket2.nextHeaders as UdpHeader).checksum)
+        // edge case where we had extra left in the stream
+        assertFalse(stream2.hasRemaining())
     }
 }


### PR DESCRIPTION
Checksums for transport layer were not previously called during the `toByteArray` function within the Packet class leading to erroneous use where the checksum was not computed before sending the packet to a byte array. The packet class is a perfect spot for it since it already has the payload and the IP header which are both required to compute the checksum.